### PR TITLE
Replace "Github" with "GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Delete multiple branches Github Action
+# Delete multiple branches GitHub Action
 
 An action that deletes multiple branches from repository.
 Optionally one can provide a `prefix` or `suffix` strings that would be appended or prepended to every branch name.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: red
 inputs:
   github_token:
-    description: Github token
+    description: GitHub token
     required: false
     default: ${{github.token}}
   branches:


### PR DESCRIPTION
It also should be replaced in the repository description.

> ⚙️ A Github Action to delete multiple branches